### PR TITLE
multi: add zstd support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/jharveyb/logrotate
+
+go 1.22
+
+toolchain go1.22.3
+
+require github.com/klauspost/compress v1.17.9

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
+github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=

--- a/main.go
+++ b/main.go
@@ -14,14 +14,15 @@
 //
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 // AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 // Command logrotate writes and rotates logs read from stdin.
 package main
@@ -32,21 +33,26 @@ import (
 	"log"
 	"os"
 
-	"github.com/jrick/logrotate/rotator"
+	"github.com/jharveyb/logrotate/rotator"
 )
 
 var (
 	flagT = flag.Bool("t", false, "Behave like tee(1)")
 	flagC = flag.Int("c", 5000, "Max (uncompressed) logfile size in kB")
-	flagR = flag.Int("r", 0, "Max number of roll files to keep, 0 is unlimited")
+	flagR = flag.Int(
+		"r", 0, "Max number of roll files to keep, 0 is unlimited",
+	)
 )
 
 func init() {
 	log.SetFlags(0)
 	log.SetPrefix(os.Args[0] + ": ")
 
+	helpMsg := "Usage: <process that outputs to stdout> | logrotate [-t] " +
+		"[-c <N>] <filename>"
+
 	flag.Usage = func() {
-		fmt.Fprintln(os.Stderr, "Usage: <process that outputs to stdout> | logrotate [-t] [-c <N>] <filename>")
+		fmt.Fprintln(os.Stderr, helpMsg)
 		flag.PrintDefaults()
 	}
 	flag.Parse()


### PR DESCRIPTION
ZSTD is both faster and compresses at higher ratios than gzip, so it would be useful to have it as an option when rotating logs.

Further pro-ZSTD arguments here:

https://github.com/golang/go/issues/62513