### PR TITLE
join errors from defers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/jrick/logrotate
 
-go 1.17
+go 1.22


### PR DESCRIPTION
If we bump to go version past 1.20, we can easily join the errors from deferred closes instead of overwriting the error:

```go
defer func() {
		err = errors.Join(err, inFile.Close())
	}()
```

If moving past 1.17 is not desirable, I think the alternative would be:

```go
defer func() {
		inCloseErr := inFile.Close()
		if err == nil {
			err = inCloseErr
		}

		err = fmt.Errorf("%w, %w", err, inCloseErr)
	}()
```

Source: https://wstrm.dev/posts/errors-join-heart-defer/