### PR TITLE
Perform compression under a mutex

### DIFF
--- a/rotator/rotator.go
+++ b/rotator/rotator.go
@@ -56,6 +56,7 @@ type Rotator struct {
 	tee       bool
 	zw        Compressor
 	zSuffix   string
+	zMu       sync.Mutex
 	wg        sync.WaitGroup
 }
 
@@ -228,6 +229,9 @@ func (r *Rotator) rotate() error {
 	if r.zw != nil {
 		r.wg.Add(1)
 		go func() {
+			r.zMu.Lock()
+			defer r.zMu.Unlock()
+
 			err := r.compress(rotname)
 			if err == nil {
 				os.Remove(rotname)


### PR DESCRIPTION
With the change to a single compression object instead of constructing new ones each time in compress(), it is possible to data race by using the compressor from two background compression goroutines at once.  Add a mutex to protect this access and prevent this situation.